### PR TITLE
Fix copying a bunch of whitespace on the copy URL button

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -82,8 +82,7 @@
                                     <td>
                                         <i class="bi bi-clipboard copylink" title="click to copy download URL"
                                            data-filename="{{$File->filename}}"
-                                           data-url="{{route('downloadpage', ['fileuuid' => $File->file_uuid,'filekey'=>$File->download_key])}}
-                                               "></i>
+                                           data-url="{{route('downloadpage', ['fileuuid' => $File->file_uuid,'filekey'=>$File->download_key])}}"></i>
                                         <a href="{{route('processdownload', ['fileuuid' => $File->file_uuid,'filekey'=>$File->download_key])}}"><i
                                                 class="bi bi-download"></i>
                                         </a>


### PR DESCRIPTION
When you click the copy URL button next to an upload, it also copies a bunch of whitespace, which is really annoying and unnecessary.
This fixes that.